### PR TITLE
Revise spambot logic

### DIFF
--- a/TelegramBots/spamBot/spamBot.js
+++ b/TelegramBots/spamBot/spamBot.js
@@ -72,8 +72,8 @@ async function deleteRestrictedMessages(msg) {
   const username = author.username;
   const chatId = msg.chat.id;
   const messageId = msg.message_id;
-  // isAdmin(chatId, author.id).then((res)=>{
-    // if (res === true) { return; }
+  isAdmin(chatId, author.id).then((res)=>{
+    if (res === true) { return; }
     if (forwardMessageCheck(msg)) {
       deleteMessageAndRespond(chatId, messageId, forwardedMessageRejection(username));
     } else if (blacklistWordsCheck(msg.text)) {
@@ -81,7 +81,7 @@ async function deleteRestrictedMessages(msg) {
     } else if (blacklistUsernameCheck(username)) {
       deleteMessageAndRespond(chatId, messageId, badUsernameRejection(username));
     }
-  // });
+  });
 }
 
 bot.on('message', deleteRestrictedMessages);

--- a/TelegramBots/spamBot/spamBot.js
+++ b/TelegramBots/spamBot/spamBot.js
@@ -76,9 +76,9 @@ async function deleteRestrictedMessages(msg) {
     if (res === true) { return; }
     if (forwardMessageCheck(msg)) {
       deleteMessageAndRespond(chatId, messageId, forwardedMessageRejection(username));
-    } else if (blacklistWordsCheck(msg.text)) {
+    } else if (msg.text && blacklistWordsCheck(msg.text)) {
 			deleteMessageAndRespond(chatId, messageId, badWordRejection(username));
-    } else if (blacklistUsernameCheck(username)) {
+    } else if (username && blacklistUsernameCheck(username)) {
       deleteMessageAndRespond(chatId, messageId, badUsernameRejection(username));
     }
   });


### PR DESCRIPTION
This PR does the following:
- Revises the spam bot to avoid checking for text in messages that do not contain text
- Fixes an accidentally commented out portion of code

This addresses issue #6