### PR TITLE
Twitter bot link

### DIFF
--- a/TelegramBots/twitterBot/twitterBot.js
+++ b/TelegramBots/twitterBot/twitterBot.js
@@ -38,10 +38,12 @@ const retrieveLatestTweet = (callback) => {
 cron.schedule('*/5 * * * *', () => {
   retrieveLatestTweet((tweet) => {
     const latestTweetId = tweet.id;
+    const latestTweetIdStr = tweet.id_str;
     const latestTweetText = tweet.full_text;
     if (latestTweetId !== params.since_id) {
       params.since_id = latestTweetId;
-      bot.sendMessage(CHAT_ID, latestTweetText, {disable_web_page_preview: true});
+      const fullMessage = `${tweet.full_text}\nhttps://twitter.com/${params.screen_name}/status/${latestTweetIdStr}`
+      bot.sendMessage(CHAT_ID, fullMessage, {disable_web_page_preview: true});
     }
   });
 });


### PR DESCRIPTION
Resolves issue #12 of twitterBot not linking to chat effectively

In testing, the bot successfully added a link to the most recent tweet:
<img width="659" alt="screen shot 2018-09-06 at 12 05 19 pm" src="https://user-images.githubusercontent.com/30442914/45179373-30cdb600-b1cd-11e8-93ef-0c75166790e2.png">
