### PR TITLE
Add twitterBot condition case for no tweets returned by API

### DIFF
--- a/TelegramBots/twitterBot/twitterBot.js
+++ b/TelegramBots/twitterBot/twitterBot.js
@@ -31,6 +31,7 @@ const retrieveLatestTweet = (callback) => {
       if (tweets[0]) {
         callback(tweets[0]);
       } else {
+        console.log(`tweets[0] undefined at ${Date.now()}`);
         console.log(tweets);
       }
     } else {

--- a/TelegramBots/twitterBot/twitterBot.js
+++ b/TelegramBots/twitterBot/twitterBot.js
@@ -28,7 +28,11 @@ let params = {screen_name: 'KK_ncnt', since_id: 1, tweet_mode: 'extended'};
 const retrieveLatestTweet = (callback) => {
   client.get('statuses/user_timeline', params, function(error, tweets, response) {
     if (!error) {
-      callback(tweets[0]);
+      if (tweets[0]) {
+        callback(tweets[0]);
+      } else {
+        console.log(tweets);
+      }
     } else {
       console.log(error);
     }


### PR DESCRIPTION
This PR does the following:
- Adds a conditional check for the existence of tweets after an API call. If there are no tweets, we log the object that was returned (this should help us to identify future issues.

Fixes issue #18