### PR TITLE
Modify twitter bot cron (5 min -> 15 min)

### DIFF
--- a/TelegramBots/twitterBot/twitterBot.js
+++ b/TelegramBots/twitterBot/twitterBot.js
@@ -40,7 +40,7 @@ const retrieveLatestTweet = (callback) => {
   });
 };
 
-cron.schedule('*/5 * * * *', () => {
+cron.schedule('*/15 * * * *', () => {
   retrieveLatestTweet((tweet) => {
     const latestTweetId = tweet.id;
     const latestTweetIdStr = tweet.id_str;


### PR DESCRIPTION
This PR addresses Issue #24 which details a needed change to the twitterBot CRON schedule.

Now the bot will do the following:
- Every 15 minutes:
  - Message the chat KK's most recent tweet if it hasn't been messaged to the chat yet